### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/dataherb/core/base.py
+++ b/dataherb/core/base.py
@@ -1,7 +1,7 @@
 import logging
 import io
 import json
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from dataherb.utils.data import flatten_dict as _flatten_dict
 from dataherb.fetch.remote import get_data_from_url as _get_data_from_url
 import ruamel.yaml as yaml

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - click==7.0
   - pip
   - pip:
-    - fuzzywuzzy>=0.18.0
-    - python-Levenshtein>=0.12
+    - rapidfuzz>=0.2.2
     - ruamel.yaml>=0.16.10
     - inquirer>=2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 pandas>=0.23
 requests>=2.22.0
-fuzzywuzzy>=0.18.0
+rapidfuzz>=0.2.2
 ruamel.yaml>=0.16.10
-python-Levenshtein>=0.12
 click==7.0
 inquirer>=2.6.3
 colorama>=0.4.3


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.